### PR TITLE
fix-userstests: Remove hardcoded ID query from users tests

### DIFF
--- a/users/tests.py
+++ b/users/tests.py
@@ -8,41 +8,37 @@ from datetime import datetime
 # Create your tests here.
 
 class ProfileModelTest(TestCase):
+    user = None
+
     def setUp(self):
-        User.objects.create(id=1, first_name='John', last_name='Smith')
+        self.user = User.objects.create(id=1, first_name='John', last_name='Smith')
         profile = User.profile
         profile.ssn = "555-55-5555"
         profile.district = "BaltimoreCounty"
         profile.middle_name = "Jack"
 
     def test_ssn_label(self):
-        user = User.objects.get(id=1)
-        field_label = user.profile._meta.get_field('ssn').verbose_name
+        field_label = self.user.profile._meta.get_field('ssn').verbose_name
         self.assertEqual(field_label, 'ssn')
 
     def test_district_label(self):
-        user = User.objects.get(id=1)
-        field_label = user.profile._meta.get_field('district').verbose_name
+        field_label = self.user.profile._meta.get_field('district').verbose_name
         self.assertEqual(field_label, 'district')
 
     def test_middle_name_label(self):
-        user = User.objects.get(id=1)
-        field_label = user.profile._meta.get_field('middle_name').verbose_name
+        field_label = self.user.profile._meta.get_field('middle_name').verbose_name
         self.assertEqual(field_label, 'middle name')
 
     def test_ssn_max_length(self):
-        user = User.objects.get(id=1)
-        max_length = user.profile._meta.get_field('ssn').max_length
+        max_length = self.user.profile._meta.get_field('ssn').max_length
         self.assertEqual(max_length, 20)
 
     def test_district_max_length(self):
-        user = User.objects.get(id=1)
-        max_length = user.profile._meta.get_field('district').max_length
+        max_length = self.user.profile._meta.get_field('district').max_length
         self.assertEqual(max_length, 50)
 
     def test_middle_name_max_length(self):
-        user = User.objects.get(id=1)
-        max_length = user.profile._meta.get_field('middle_name').max_length
+        max_length = self.user.profile._meta.get_field('middle_name').max_length
         self.assertEqual(max_length, 30)
 
 class LoginFlowTests(TestCase):


### PR DESCRIPTION
To test:
- Verify that `python manage.py tests` passes with no reported errors!